### PR TITLE
feat(ch5): prevent creating Project as Closed

### DIFF
--- a/force-app/main/default/classes/ProjectService.cls
+++ b/force-app/main/default/classes/ProjectService.cls
@@ -1,6 +1,10 @@
 public with sharing class ProjectService {
 
     public static Project__c createProject(String name, String status) {
+        if (status == 'Closed') {
+            throw new IllegalArgumentException('Project cannot be created as Closed');
+        }
+
         Project__c p = new Project__c(
             Name = name,
             Status__c = status

--- a/force-app/main/default/classes/ProjectServiceTest.cls
+++ b/force-app/main/default/classes/ProjectServiceTest.cls
@@ -1,13 +1,13 @@
 @IsTest
 private class ProjectServiceTest {
-
-    @IsTest
-    static void shouldCreateProject() {
-        Test.startTest();
-        Project__c p = ProjectService.createProject('Test Project', 'Draft');
-        Test.stopTest();
-
-        System.assertNotEquals(null, p.Id, 'Project should have been inserted');
-        System.assertEquals('Draft', p.Status__c);
+    static void shouldNotAllowClosedProjectOnCreate() {
+        try {
+            ProjectService.createProject('Invalid Project', 'Closed');
+            System.assert(false, 'Exception should have been thrown');
+        } catch (Exception e) {
+            System.assert(
+                e.getMessage().contains('cannot be created as Closed')
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #5 

## O que mudou
- Adicionada validação para impedir Project com status Closed na criação
- Teste unitário cobrindo cenário inválido

## Como validar
- sf project deploy start --source-dir force-app
- sf apex run test --class-names ProjectServiceTest --synchronous
